### PR TITLE
fix: Make Payload < 10Mo limit

### DIFF
--- a/src/cron/cron.py
+++ b/src/cron/cron.py
@@ -93,23 +93,27 @@ USER_LAST_LOGIN_INDEX = 4
 def normalize_date(value: date|None) -> str|None:
     return value.strftime('%Y-%m-%d') if value is not None else value
 
-for idx, user in enumerate(users):
-    user = list(user)
-    email = user.pop(EMAIL_ATTR_INDEX)
-    user[USER_FIRST_LOGIN_INDEX] = normalize_date(user[USER_FIRST_LOGIN_INDEX])
-    user[USER_LAST_LOGIN_INDEX] = normalize_date(user[USER_LAST_LOGIN_INDEX])
-    brevo_payload["jsonBody"].append(
-        {
-            "email": email,
-            "attributes" : dict(zip(brevo_attributes, user))
-        }
-    )
+def prepare_payload(users):
+    for user in users:
+        user = list(user)
+        email = user.pop(EMAIL_ATTR_INDEX)
+        user[USER_FIRST_LOGIN_INDEX] = normalize_date(user[USER_FIRST_LOGIN_INDEX])
+        user[USER_LAST_LOGIN_INDEX] = normalize_date(user[USER_LAST_LOGIN_INDEX])
+        brevo_payload["jsonBody"].append(
+            {
+                "email": email,
+                "attributes" : dict(zip(brevo_attributes, user))
+            }
+        )
 
-    if ((idx + 1) % MAX_BATCH_SIZE == 0) or (idx == len(users) - 1):
-        response = requests.post(brevo_url, json=brevo_payload, headers=brevo_headers)
-        print(response.text)
-        if response.status_code != 200:
-            error_counter += 1
-        brevo_payload["jsonBody"] = []
+chunked_users = [users[start:start+MAX_BATCH_SIZE] for start in range(0,len(users),MAX_BATCH_SIZE)]
+
+for chunk in chunked_users:
+    brevo_payload["jsonBody"] = []
+    prepare_payload(chunk)
+    response = requests.post(brevo_url, json=brevo_payload, headers=brevo_headers)
+    print(response.text)
+    if response.status_code != 200:
+        error_counter += 1
 
 sys.exit(error_counter)


### PR DESCRIPTION
For user batch import Brevo specified that "Maximum allowed json body size is 10MB". Our instance have grown to quickly so we reach that limit. The proposed solution is to set a limit of 5000 user per batch (as it was working when our instance had this volume of users).

Other improvement, the script can now give another exit status than 0. That must ensure that our monitoring can detect when a Cron fails.