### PR TITLE
fix: exclude invalid emails from queries

### DIFF
--- a/src/cron/cron.py
+++ b/src/cron/cron.py
@@ -41,6 +41,7 @@ with psycopg.connect(conninfo=os.environ["PG_URL"]) as conn:
                     users LEFT JOIN
                     logins ON users.id = logins.user_id LEFT JOIN
                     docs ON logins.user_id = docs.created_by
+                WHERE logins.display_email NOT LIKE '% %'
             )
             SELECT 
                 EMAIL,


### PR DESCRIPTION
for some reason users managed to push a lot of trash emails when inviting people to documents